### PR TITLE
크롤링 데이터 전처리, 토큰 길이 측정, 질문 데이터셋 GPT로 생성하는 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,168 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+
+# Other files
+*.csv
+*.xlsx
+*.json
+*.jsonl
+.DS_Store

--- a/generate_question.py
+++ b/generate_question.py
@@ -1,0 +1,109 @@
+# TODO: .env에 {OPENAI_API_KEY=...} 형식의 openai key가 필요함
+from dotenv import load_dotenv
+load_dotenv()
+from tqdm import tqdm
+import pandas as pd
+import jsonlines
+import json
+
+import openai
+
+class GenerateQuestion :
+    def __init__(self, jsonl_input_path: str = "./files/title_desc_passage.jsonl", jsonl_output_path: str = "./files/qa_gpt_dataset.jsonl", title: str = "title", description: str = "description") :
+        '''
+            Args:
+                jsonl_input_path : 질문을 생성할 기반 문서 (JSONL) 파일의 경로, 430 토큰 미만으로 Split 할 것을 권장.
+                json_output_path : Q-A-CTXs DPR 데이터셋을 저장할 경로 (JSON)
+
+                title : 데이터 내 "제목"의 필드값 (key)
+                description : 데이터 내 "큐레이션 설명"의 필드값 (key)
+        '''
+        self.jsonl_input_path = jsonl_input_path
+        self.jsonl_output_path = jsonl_output_path
+
+        self.title = title
+        self.description = description
+
+    def load_data(self):
+        data_list = []
+        with jsonlines.open(self.jsonl_input_path) as file:
+            for line in file.iter():
+                data_list.append(line)
+        return data_list
+    
+    def generate_question(
+            self,
+            model='gpt-3.5-turbo',
+            max_retries=3
+        ):
+
+        # i=0
+        dataset = []
+        with jsonlines.open(self.jsonl_input_path) as file:
+            try :
+                for data in tqdm(file.iter()):
+                    title = data[self.title]
+                    # print(f'load data.. title:{title}')
+                    description = data[self.description]
+                    # print(f'load data.. description:{description}')
+                    
+                    # 요청 보내기
+                    response = openai.ChatCompletion.create(
+                        model = model,
+                        messages = [
+                            {
+                                'role' : 'system',
+                                'content' : '너는 박물관 AI 도슨트야. 아래에 제시된 제목과 해설을 기반으로 관람객들이 물어볼만한 질문과 답변을 해설마다 10쌍씩 생성해줘. 문서에서 답변할 수 없는 질문은 제외하되, 직접적으로 정답이 되는 키워드 사용도 피해줘. 제목이 같다면 이전 문서를 참고해도 좋아. 포맷은 "질문: {q}, 답변: {a}" 으로 생성해줘. 질문에는 어떤 작품을 지칭하는지가 꼭 포함되어야해.'
+                            },
+                            {
+                                'role' : 'user',
+                                'content' : f'문서->\n제목: {title} \n해설:{description}]'
+                            }
+                        ]
+                    )
+
+                    # 재시도 3회까지 허용
+                    retries = 0
+                    while retries <= max_retries :
+                        print(f'{retries}회 시도 중..')
+                        if response.choices and response.choices[0].message['content'] :
+                            try :
+                                qa_pair = response.choices[0].message['content'].strip()
+                                retries = max_retries+1
+                            except Exception as e:
+                                print(f"{e} question 생성 실패 오류 발생, 재시도 중 ...")
+                                retries += 1
+                                if retries > max_retries:
+                                    qa_pair = '생성 후 실패'
+                                    continue
+                        else :
+                            retries += 1
+                            if retries > max_retries:
+                                print(f"재시도 횟수 초과. 다음 요청으로 넘어갑니다.")
+                                qa_pair = '실패'
+                                continue
+                            print(f"연결 실패.. {retries}/{max_retries}회 에러")
+
+                    dataset.append({'title':title, 'context':description, 'question':qa_pair})
+                    # 시범용
+                    # if i == 10 :
+                        # break
+                    # i += 1
+            except Exception as ee:
+                dataset.append({'title':'실패', 'context':'실패', 'question':'실패'})
+            
+            # 일단 csv로도 저장
+            df = pd.DataFrame(dataset)
+            df.to_csv("./files/qa_gpt_df.csv", index=False, encoding="utf-8-sig")
+
+        return dataset
+    
+    def save_data(self, dataset):
+        with open(self.jsonl_output_path, 'w', encoding='utf-8') as write_file:
+            write_file.write(json.dumps(dataset, ensure_ascii=False) + "\n")
+
+if __name__ == "__main__" :
+    gq = GenerateQuestion()
+    dataset = gq.generate_question()
+    gq.save_data(dataset)
+    print('끝.')

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,0 +1,175 @@
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import BertTokenizerFast
+import tiktoken
+import json
+
+class Preprocessing :   
+    def __init__(self, jsonl_input_path: str = "./files/museum_passage.jsonl", jsonl_output_path: str = "./files/passage_split.jsonl", encoding_name: str = "klue/bert-base") :
+        '''
+            Args:
+                jsonl_input_path: 크롤링 데이터 원본을 담고 있는 JSONL 파일의 경로
+                jsonl_output_path : 파일을 저장할 경로  
+                encoding_name :
+                    - BERT로 임베딩할 시 : "klue/bert-base"
+                    - gpt-3.5-turbo 등으로 임베딩할 시 : "cl100k_base"
+        '''
+        self.jsonl_input_path = jsonl_input_path
+        self.jsonl_output_path = jsonl_output_path
+        self.encoding_name = encoding_name
+
+    def load_data(self):
+        data_list = []
+        with open(self.jsonl_input_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                data_list.append(line)
+        return data_list
+
+    def bert_token_len(self, text):
+        encoding_name = self.encoding_name
+        tokenizer = BertTokenizerFast.from_pretrained(encoding_name)
+        tokens = tokenizer(text, return_tensors='pt')
+        return len(tokens)
+
+    def bert_split(self, data):
+        '''
+            Desc:
+                원본 크롤링 파일 (.jsonl) 문장에서 설명 부분이 380토큰 (BERT 기준) 넘어갈 경우 Split함
+            Args:
+                data : 크롤링 파일
+                jsonl_output_path : 파일을 저장할 경로  
+        '''
+        encoding_name = self.encoding_name
+        tokenizer = BertTokenizerFast.from_pretrained(encoding_name)
+        splitter = RecursiveCharacterTextSplitter.from_huggingface_tokenizer(chunk_size=380, chunk_overlap=50, tokenizer=tokenizer, separators=["한편", "이 밖에도", ". "], keep_separator=False)
+        
+        # TODO: key가 description이어야 함 -> 없으면 KeyError 발생
+        with open(self.jsonl_output_path, 'w', encoding='utf-8') as jsonl_file :
+            for line in data:
+                try :
+                    text_dict = json.loads(line)
+                    text = text_dict['description']
+                    # print(text)
+                except KeyError:
+                    raise KeyError("작품 설명의 key값을 'description'으로 설정하세요.")
+
+                split_data = splitter.split_text(text)
+                for single_split_data in split_data :
+                    # print(f'split... -> {single_split_data}')
+                    new_line = text_dict
+                    new_line['description'] = single_split_data
+                    print(f'new_line: {new_line}')
+                    json.dump(new_line, jsonl_file, ensure_ascii=False)
+                    jsonl_file.write('\n')
+
+    def tiktoken_len(self, text, encoding_name="cl100k_base"):
+        '''
+            Desc:
+                tiktoken library를 활용해 토큰 길이를 계산하는 함수
+            Args:
+                1. text : 토큰 길이 측정할 텍스트
+                2. encoding_name : 토큰으로 변환할 방식 지정
+                    - cl100k_base : gpt-3.5-turbo, gpt-4, text-embedding-ada-002 모델 사용시
+                    - p50k_base : text-davinci-002, text-davinci-003 모델 사용시
+                    - r50k_base (or gpt2) : GPT-3 models like "davinci"
+        '''
+        tokenizer = tiktoken.get_encoding(encoding_name)
+        # tokenizer = tiktoken.encoding_for_model("gpt-3.5-turbo") # 위 코드로 안될 시 모델 이름 넣어서 이걸로 해보기
+        tokens = tokenizer.encode(text)
+        return len(tokens)
+
+    def tiktoken_split(self, data):
+        '''
+            Desc:
+                원본 크롤링 파일 (.jsonl) 문장에서 설명이 2000토큰이 (cl100k_base 기준) 넘어갈 경우 Split함
+            Args:
+                data : 크롤링 파일
+        '''
+        splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(chunk_size=2000, chunk_overlap=100)
+
+        with open(self.jsonl_output_path, 'w', encoding='utf-8') as jsonl_file :
+            for line in data:
+                # description 부분만 받아오기 -> 없으면 KeyError 발생
+                try :
+                    text_dict = json.loads(line)
+                    text = text_dict['description']
+                except KeyError:
+                    raise KeyError("작품 설명의 key값을 'description'으로 설정하세요.")
+                token_len = self.tiktoken_len(text)
+
+                # 토큰 길이가 2000을 넘을 경우 문서 Split
+                if token_len > 2000 :
+                    split_data = splitter.split_text(text)
+                    for single_split_data in split_data :
+                        # print(f'split... -> {single_split_data}')
+                        new_line = text_dict
+                        new_line['description'] = single_split_data
+                        json.dump(new_line, jsonl_file, ensure_ascii=False)
+                        jsonl_file.write('\n')
+                else :
+                    json.dump(text_dict, jsonl_file, ensure_ascii=False)
+                    jsonl_file.write('\n')
+    
+    def tiktoken_len_check(self, encoding_name="cl100k_base"):
+        len_list = []
+        with open(self.jsonl_input_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                tokenizer = tiktoken.get_encoding(encoding_name)
+                tokens = tokenizer.encode(line)
+                line = json.loads(line)
+                len_list.append({len(tokens):line['title']})
+        print(len_list)
+        return len(tokens)
+    
+    def bert_len_check(self, encoding_name):
+        encoding_name = self.encoding_name
+        len_list = []
+        over_list = []
+        with open(self.jsonl_input_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                tokenizer = BertTokenizerFast.from_pretrained(encoding_name)
+                tokens = tokenizer(line, return_tensors='pt')['input_ids']
+                line = json.loads(line)
+                if tokens.size(1) > 450 :
+                    len_list.append({line['title']:tokens.size(1)})
+                print(f'"{line["title"]}" 하는 중.. Token Length : {tokens.size(1)}')
+        print(len_list)
+        return tokens.size(1)
+
+    # 수정 예정
+    # def combine_era_info(self, data):
+
+    def process(self):
+        if self.encoding_name == "klue/bert-base" :
+            print('Running bert_split')
+            data = self.load_data()
+            # print(data[1])
+            self.bert_split(data)
+        elif self.encoding_name == "cl100k_base" :
+            print('Running tiktoken_split')
+            data = self.load_data()
+            self.tiktoken_split(data)
+
+if __name__ == "__main__" : # python preprocessing.py로 실행할 경우
+    
+    ## bert 기반 tokenizing 후 split을 진행할 경우
+    ## museum_passage.jsonl : 원본 크롤링 데이터, passage_bert_split.jsonl : split 후 저장할 파일명 (변경 가능)
+    # pp = Preprocessing('./files/museum_passage.jsonl', './files/passage_bert_split.jsonl', encoding_name='klue/bert-base')
+    # pp.process()
+
+    ## tiktoken(cl100k-base)으로 tokenizing 후 split을 진행할 경우 (gpt-3.5-turbo)
+    ## museum_passage.jsonl : 원본 크롤링 데이터, passage_tiktoken_split.jsonl : split 후 저장할 파일명 (변경 가능)
+    # pp = Preprocessing('./files/museum_passage.jsonl', './files/passage_tiktoken_split.jsonl', encoding_name='cl100k_base')
+    # pp.process()
+
+    ## tiktoken 기반 토큰 갯수 체크
+    ## input만 넣어도 됨
+    # pp = Preprocessing(jsonl_input_path='./files/passage_tiktoken_split.jsonl', jsonl_output_path='./files/passage_tiktoken_split.jsonl')
+    # pp.tiktoken_len_check()
+
+    ## bert 기반 토큰 갯수 체크
+    ## input만 넣어도 됨
+    # pp = Preprocessing(jsonl_input_path='./files/passage_bert_split.jsonl', jsonl_output_path='./files/passage_bert_split.jsonl')
+    # pp.bert_len_check()
+
+    pp = Preprocessing(jsonl_input_path='./files/title_desc_passage.jsonl')
+    pp.bert_len_check(encoding_name='klue/bert-base')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+langchain
+openai
+streamlit
+webdriver_manager==4.0.1
+selenium
+beautifulsoup4
+tqdm
+pandas
+transformers
+tiktoken
+dotenv
+jsonlines


### PR DESCRIPTION
1. .gitignore 생성
    - 파일 관리의 용이성을 위해 *.csv, *.json, *.jsonl, .DS_Store, *.xlsx 등을 추가 (파일 하단에 위치)
  
2. requirements.txt 생성

3. preprocessing.py
    - 메인 기능 : 크롤링 데이터 split, 토큰 길이 측정 (tiktoken, bert 두 가지 버전)
    - input 파일만 있으면 바로 main에서도 실행 가능함
    - era, info 필드를 description으로 combine하는 코드는 추후 추가 예정

4. generate_question.py
    - 메인 기능 : gpt-3.5-turbo로 passage를 보내서 질문-답변 쌍을 10개씩 받아오도록 함
    - 프롬프트 다양한 시도 중.. 더 좋은 성능을 보이는 프롬프트가 있다면 지속적으로 수정할 예정
    - 연결 이슈가 종종 있어서 우선 실험용으로 10개 passage만 보내볼 것
    - input 파일만 있으면 main에서 바로 실행 가능함